### PR TITLE
fix: use default import for DryRunDashboard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import { Navigation, Page } from "./components/Navigation";
 import { UserCreationForm } from "./components/UserCreationForm";
 import PromptWorkbench from "./echomind/PromptWorkbench";
 import { useDryRun } from "./dryrun/DryRunProvider";
-import { DryRunDashboard } from "./dryrun/DryRunDashboard";
+import DryRunDashboard from "./dryrun/DryRunDashboard";
 import { THEME } from "./components/theme";
 
 const AppContent: React.FC = () => {


### PR DESCRIPTION
Switches from named to default import to match export in DryRunDashboard.tsx. Fixes the Vite/React error on startup.